### PR TITLE
Fixed conky opening in a new window

### DIFF
--- a/frappe.conf
+++ b/frappe.conf
@@ -70,8 +70,8 @@ conky.config = {
 	own_window_class = 'Conky',					-- manually set the WM_CLASS name for use with xprop
 	own_window_colour = '#303446',				-- set colour if own_window_transparent no
 	own_window_transparent = false,				-- if own_window_argb_visual is true sets background opacity 0%
-	own_window_title = 'conky',			-- set the name manually
-	own_window_type = 'desktop',				-- if own_window true options are: normal/override/dock/desktop/panel
+	own_window_title = 'conky',			        -- set the name manually
+	own_window_type = 'override',				-- if own_window true options are: normal/override/dock/desktop/panel
 	own_window_hints = 'undecorated,below,above,sticky,skip_taskbar,skip_pager',  -- if own_window true - just hints - own_window_type sets it
 
 	--catppuccin

--- a/latte.conf
+++ b/latte.conf
@@ -71,7 +71,7 @@ conky.config = {
 	own_window_colour = '#eff1f5',				-- set colour if own_window_transparent no
 	own_window_transparent = false,				-- if own_window_argb_visual is true sets background opacity 0%
 	own_window_title = 'conky',			-- set the name manually
-	own_window_type = 'desktop',				-- if own_window true options are: normal/override/dock/desktop/panel
+	own_window_type = 'override',				-- if own_window true options are: normal/override/dock/desktop/panel
 	own_window_hints = 'undecorated,below,above,sticky,skip_taskbar,skip_pager',  -- if own_window true - just hints - own_window_type sets it
 
 	--catppuccin

--- a/macchiato.conf
+++ b/macchiato.conf
@@ -71,7 +71,7 @@ conky.config = {
 	own_window_colour = '#24273a',				-- set colour if own_window_transparent no
 	own_window_transparent = false,				-- if own_window_argb_visual is true sets background opacity 0%
 	own_window_title = 'conky',			-- set the name manually
-	own_window_type = 'desktop',				-- if own_window true options are: normal/override/dock/desktop/panel
+	own_window_type = 'override',				-- if own_window true options are: normal/override/dock/desktop/panel
 	own_window_hints = 'undecorated,below,above,sticky,skip_taskbar,skip_pager',  -- if own_window true - just hints - own_window_type sets it
 
 	--catppuccin

--- a/mocha.conf
+++ b/mocha.conf
@@ -70,8 +70,8 @@ conky.config = {
 	own_window_class = 'Conky',					-- manually set the WM_CLASS name for use with xprop
 	own_window_colour = '#1e1e2e',				-- set colour if own_window_transparent no
 	own_window_transparent = false,				-- if own_window_argb_visual is true sets background opacity 0%
-	own_window_title = 'conky',			-- set the name manually
-	own_window_type = 'desktop',				-- if own_window true options are: normal/override/dock/desktop/panel
+	own_window_title = 'conky',			        -- set the name manually
+	own_window_type = 'override',				-- if own_window true options are: normal/override/dock/desktop/panel
 	own_window_hints = 'undecorated,below,above,sticky,skip_taskbar,skip_pager',  -- if own_window true - just hints - own_window_type sets it
 
 	--catppuccin


### PR DESCRIPTION
When one loaded the previous conky config, it opened in its own window as seen below. my commit fixes this issue.
![image](https://user-images.githubusercontent.com/64868985/212514234-19c21c0f-c2fc-4ae3-b5fc-5b68a882bd61.png)
